### PR TITLE
Add DualSense to the motion controls page

### DIFF
--- a/_pages/en_US/controllers/controllers-ps.md
+++ b/_pages/en_US/controllers/controllers-ps.md
@@ -10,11 +10,11 @@
 
 1. Download and extract DS4Windows to your computer
   - Select the `_x64.zip` file
-1. Connect your Dualshock 4 controller to Windows via Bluetooth
+1. Connect your DualShock 4 or DualSense controller to Windows via USB or Bluetooth
+  - Motion controls with the DualSense currently only supports USB connections
 1. Open the DS4Windows application
 1. Ensure your controller is registered with DS4Windows
 1. Navigate to the `Settings` tab
-1. Enable `Hide DS4 Controller`
 1. Enable `UDP Server`
   - This should say `127.0.0.1` with port `26760`
 

--- a/_pages/en_US/controllers/motion-controls.md
+++ b/_pages/en_US/controllers/motion-controls.md
@@ -6,21 +6,21 @@ excerpt: Setting up motion controls for different controllers in the Cemu emulat
 
 In this section we'll be configuring controller inputs and motion controls for Cemu.
 
-Only a select few controllers properly support motion controls. We recommend using either official Nintendo Switch controllers or a Dual Shock 4 controller.
+Only a select few controllers properly support motion controls. We recommend using either official Nintendo Switch or PlayStation controllers.
 
 If you have an Xbox controller, this will not work as they don't have the hardware to support motion controls. For other controllers, please check the "Others" tab to see compatibility.
 
 Please select your controller type below:
 
 <button class="btn btn--large btn--info" id="abtn" onclick="showa()">Nintendo Switch</button>
-<button class="btn btn--large btn--info" id="bbtn" onclick="showb()">Dualshock 4</button>
+<button class="btn btn--large btn--info" id="bbtn" onclick="showb()">PlayStation</button>
 <button class="btn btn--large btn--info" id="cbtn" onclick="showc()">Xbox</button>
 <button class="btn btn--large btn--info" id="dbtn" onclick="showd()">Others</button>
 
 {% capture a-instructions %}{% include_relative controllers-switch.md %}{% endcapture %}
 <div id="ainstr">{{ a-instructions | markdownify }}</div>
 
-{% capture b-instructions %}{% include_relative controllers-ds4.md %}{% endcapture %}
+{% capture b-instructions %}{% include_relative controllers-ps.md %}{% endcapture %}
 <div id="binstr">{{ b-instructions | markdownify }}</div>
 
 {% capture c-instructions %}{% include_relative controllers-xbox-motion.md %}{% endcapture %}


### PR DESCRIPTION
The DualSense controller is supported with the latest DS4Windows. This PR changes the motion controls page to mention the DualSense along with renaming the tab from `Dualshock 4` to `PlayStation`.

This needs a new screenshot that's only pointing to the UDP Server option, as `Hide DS4 Controller` is considered deprecated in the latest version.
<img width="419" alt="2020-11-19_18-22-15_DS4Windows" src="https://user-images.githubusercontent.com/15317421/99750796-de1f0280-2a95-11eb-914b-7efc658d7257.png">

It's worth mentioning DS4Windows has support for Switch controllers as well, but I'm unsure how well those work due to my Bluetooth adapter not being that great.