### PR TITLE
Increased Specificity for Online Setup in using-dumpling.md

### DIFF
--- a/docs/using-dumpling.md
+++ b/docs/using-dumpling.md
@@ -76,10 +76,12 @@ This can be installed like any other game dump in the next section.
 1. Exit the Dumpling app and turn off your Wii U
 1. Take your USB storage device or SD card out of your Wii U and put it in your PC
 1. Copy `otp.bin` and `seeprom.bin` from the `/dumpling/Online Files` folder to your Cemu directory
-    - This is where `Cemu.exe` is located
+    - This is where `Cemu.exe` is located on Windows
+    - On Linux, this is located in `/home/[username]/.local/share/Cemu`
 1. Copy the `sys` and `usr` folders from `/dumpling/Online Files/mlc01` on your SD/USB device to the `mlc01` folder
     - By default, the `mlc01` folder is located in the Cemu folder
     - If you are unsure where it is, check in `Options` -> `General settings` under "MLC Path"
+    -  You might have renamed `mlc01` to something different. Use the previous bullet point to find the name and path of the folder where these files must go
     - Overwrite any files if prompted
 
 Now that you have got your online data and dumps, you can proceed to the next step which takes you through how to install your games in Cemu.


### PR DESCRIPTION
Clarified where Linux users should paste otp.bin and seeprom.bin by adding a file path. I struggled with finding mlc01 because I didn't realize it could be renamed by the user, so I added an additional bullet point that reminds users to check the MLC Path in Cemu settings to find the folder name that they need to paste the sys and usr folders into.