### PR TITLE
Fix instructions to dump Friend List application

### DIFF
--- a/docs/using-dumpling.md
+++ b/docs/using-dumpling.md
@@ -67,8 +67,9 @@ We also recommend dumping the Friend List application. If you wish to play onlin
 
 This can be installed like any other game dump in the next section.
 
-1. Select `Dump files to use Cemu online`
-1. Select `Start` to begin dumping
+1. Select `Dump Wii U applications (e.g. Friend List, eShop etc.)`
+1. Select `Friend List` from the list 
+1. Press `+` then select `[Confirm]` to begin dumping
 1. When finished, go back to the Dumpling main menu
 
 ## Copying Online Files to Cemu


### PR DESCRIPTION
The previous iteration used the instructions to dump a user's online files, which did not dump the Friend List application along with it (online files are ~11MB, Friend List is 22MB). Updated to include the correct instructions to dump the Friend List application separately.